### PR TITLE
fix for mqtts not using secure client

### DIFF
--- a/src/ESP8266MQTTClient.cpp
+++ b/src/ESP8266MQTTClient.cpp
@@ -142,7 +142,7 @@ bool MQTTClient::begin(String uri, LwtOptions lwt, int keepalive, bool clean_ses
     _transportTraits.reset(nullptr);
 
 
-    if(_scheme == "mqtt" || _scheme == "mqtts") {
+    if(_scheme == "mqtt") {
         _transportTraits = MQTTTransportTraitsPtr(new MQTTTransportTraits());
     } else if(_scheme == "mqtts") {
         _transportTraits = MQTTTransportTraitsPtr(new MQTTTransportTraits(true));


### PR DESCRIPTION
When using the mqtts in url, the secure client is not used and if the mqtt is set up with TLS it will not connect...